### PR TITLE
Update RavenScript.ps1

### DIFF
--- a/RavenScript.ps1
+++ b/RavenScript.ps1
@@ -1,7 +1,8 @@
 #                           (477th Cyber Flight)
 #                   POC:  TSgt Overgaauw, DSN:  551-2666
 #                    Created Aug 19 || Modified Aug 19
-
+$CR = "`r`n"
+$failedd = ""
 $computers = gc "\\elfs2\ELWEB\Remote_Install_Scripts\477FG\computers.txt"
 $destination = "C$\Remote_Install"
 $Source = "\\elfs2\ELWEB\Remote_Install_Scripts\_Files\McAfeeFrameworkFiles"
@@ -48,6 +49,9 @@ function Show-Menu
               '1' {
                  cls
                  foreach ($computer in $computers) {
+   ##Loud but much faster than test connection
+    #{$string = "";$string = get-netadapterbinding -cimsession $computer -componentID ms_tcpip6;if ($string){$string = ""}else{ if($failedd -eq ""){$failedd = $computer}else{$failedd = $failedd +CR+$computer}}$string=""
+   ##$failedd is now an array of failed machines that can be written to the console or pushed to a file. Clear $failedd variable before pause though.
                     If (Test-connection -Cn $computer -ErrorAction SilentlyContinue) {
                         Write-Host -ForegroundColor Green "Ping successful for $computer"}
                     Else {


### PR DESCRIPTION
Used netAdapterbinding instead of test connection. NetAdapterBinding is way faster even when the buffer on test connection is set to 16. The code is on one line so you can review it without finagling with closing brackets but leaves you with the $failedd  variable that is an array of computers that couldn’t connect and this can be presented to the user via console msg.exe or otherwise. The $failed variable should also be cleared before the code block exits. 

The line finds out if the remote interface has ipv6 set. If the machine is unreachable it returns nothing but spits out an error to console ( noisy if many systems are offline) the result is stored in  $string . $string is then checked : if not empty reset to empty (the system responded). Otherwise the $string is empty (host was unreachable) and that computer to the $failedd array. If failed is currently empty the computer is simply added. If it is not empty then we use $CR (defined at the top of the script) as the power shell  new line-carriage return and append the computer thus creating an array. Followed by some clean up of clearing scoped variables. Failure to do so could cause issues if the function is run again.  Really speedy especially if your computers list is large and all the failed systems are presented in one continuous array. Sorry if it’s ugly. Typing with thumbs.